### PR TITLE
Fix unit test and minor improvements to session management

### DIFF
--- a/lib/session_box.dart
+++ b/lib/session_box.dart
@@ -31,16 +31,22 @@ class SessionBox<T> {
 
   /// Persists the full user object
   Future<void> login(T user) => _service.login(user);
+
   /// Gets the persisted user object, or `null` if none. Useful if you need fields from the stored user (e.g., email).
   Future<T?> getUser() => _service.getUser();
+
   /// Re-reads the stored user and (if `isValidUser` is set) validates it. Returns the valid user or `null` if invalid.
   Future<T?> refreshSession() => _service.refreshSession();
+
   /// Clears the persisted user and in‑memory userId.
   Future<void> logout() => _service.logout();
+
   /// Sets an in‑memory only user id (not persisted). Most apps don’t need to call this directly.
   void setUserId(int userId) => _service.setSessionUserId(userId);
+
   /// Returns the in‑memory user id (or null if not set). Requires that you set it with [setUserId]. Ideally after using refreshSession, with isValidUser passed when creating the session box.
   int? getUserId() => _service.getSessionUserId();
+
   /// true if an in‑memory user id is set.
   bool get hasUserId => _service.hasSessionUserId();
 }

--- a/lib/src/application/user_session_service.dart
+++ b/lib/src/application/user_session_service.dart
@@ -77,7 +77,8 @@ class UserSessionService<T> {
   }
 
   bool hasSessionUserId() {
-    return _userId != null;
+    final id = getSessionUserId();
+    return id != null;
   }
 
   static ToJson<T> _resolveToJson<T>(ToJson<T>? provided) {

--- a/test/user_session_manager_test.dart
+++ b/test/user_session_manager_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('Initially not logged in', () async {
-      expect(await sessionManager.refreshSession(), isFalse);
+      expect(await sessionManager.refreshSession(), isNull);
     });
 
     test('Login + Get', () async {


### PR DESCRIPTION
Update user_session_manager_test to expect null on initial session refresh. Refactor hasSessionUserId to use getSessionUserId for consistency. Add spacing for readability in session_box.dart.